### PR TITLE
Replaced sys with util.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = function fastcgi(newOptions) {
     , path    = require("path")
     , http    = require("http")
     , net     = require("net")
-    , sys     = require("sys")
+    , util     = require("util")
     , fastcgi = require("fastcgi-parser");
 
     var debug = 0 ? console : { log: function(){}, dir: function(){} };
@@ -231,7 +231,7 @@ module.exports = function fastcgi(newOptions) {
         });
 
         connection.addListener("error", function(err) {
-            sys.puts(sys.inspect(err.stack));
+            console.log(util.inspect(err.stack));
             connection.end();
         });
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "url": "https://github.com/pashky/connect-fastcgi.git"
     },
     "dependencies": {
-        "fastcgi-parser": "0.1.x"
+        "fastcgi-parser": "0.1.x",
+        "util": "0.10.3"
     },
     "engines": { "node": "*" }
 }


### PR DESCRIPTION
*sys* is replaced with *util* (and marked as __deprecated__) in NodeJS 5.1 and may be removed in near future.

I modified two lines to use *util* and added util dependency.